### PR TITLE
Escape the colons in the title (#180)

### DIFF
--- a/1209/A55A/index.md
+++ b/1209/A55A/index.md
@@ -1,6 +1,6 @@
 ---
 layout: pid
-title: USB: The Universal Serial Bus: ATTINY2313
+title: "USB: The Universal Serial Bus: ATTINY2313"
 owner: fysnet
 license: LGPLv2
 site: http://www.fysnet.net/attiny2313.htm


### PR DESCRIPTION
- Remove errant .DS_Store file
- Correct owner name
- Correct owner name
- Correct owner name
- Strip extra space
- Strip extra space
- Fix some broken formatting
- Correct filename
- Escape the colons in the title
- Try alternative escaping of the colons
